### PR TITLE
Check if the LDAP server is available before connecting

### DIFF
--- a/Driver/LdapConnection.php
+++ b/Driver/LdapConnection.php
@@ -67,7 +67,7 @@ class LdapConnection implements LdapConnectionInterface
      */
     private function checkServer() {
         $socket = @fsockopen($this->params['host'], $this->params['port'], $errno, $errstr, 2);
-
+        if(!$socket) {
             throw new AuthenticationServiceException(sprintf('LDAP Server Unavailable: Error %s: %s.', $errno, $errstr));
         }
 


### PR DESCRIPTION
Before connecting with ldap_connect and ldap_bind to the LDAP server,
the server will be pinged in order to ensure that it is available.

If this is not done, the connection will wait until it times out
(typically after 30 seconds). This way of implementing it is needed
because the PHP LDAP library does not provide a way to specify a
timeout.
