### PR TITLE
changed class type to abstract. In sf 2.3 was getting error:

### DIFF
--- a/Validator/UniqueValidator.php
+++ b/Validator/UniqueValidator.php
@@ -20,7 +20,7 @@ use FR3D\LdapBundle\Ldap\LdapManagerInterface;
 /**
  * UniqueValidator
  */
-class UniqueValidator extends ConstraintValidator
+Abstract class UniqueValidator extends ConstraintValidator
 {
     /**
      * @var LdapManagerInterface


### PR DESCRIPTION
PHP Fatal error:  Class FR3D\LdapBundle\Validator\UniqueValidator contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Symfony\Component\Validator\ConstraintValidatorInterface::validate) in /.../vendor/fr3d/ldap-bundle/FR3D/LdapBundle/Validator/UniqueValidator.php on line 68
