### PR TITLE
raise php version requirement in composer.json to 5.3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "source": "https://github.com/Maks3w/FR3DLdapBundle"
     },
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.3.3",
         "ext-ldap": "*",
         "symfony/config": ">=2.1",
         "symfony/dependency-injection": ">=2.1",


### PR DESCRIPTION
As FR3DLdapBundle relies on Symfony components, whose php requirement is 5.3.3 and up, it's not possible to declare 5.3.2 support which is defined in composer.json, therefor it should be raised to 5.3.3
BTW, travis-ci already tests against 5.3.3 and the latest from 5.3
