### PR TITLE
Fix documentation

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -111,7 +111,7 @@ security:
             id: fr3d_ldap.security.user.provider
 
         fos_userbundle:
-            id: fos_user.user_manager
+            id: fos_user.user_provider.username
 
 ```
 


### PR DESCRIPTION
fos_user.user_manager is deprecated. It has to be replaced by fos_user.user_provider.username. I changed the documentation accordingly.

For more information, see https://github.com/FriendsOfSymfony/FOSUserBundle/issues/1187
