### PR TITLE
Use token `getCrendentials` instead user `getPassword`. Fix #76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Config:
 - [BC Break] Removed `version` key in config.yml
 - [BC Break] `bindRequiredDn` it's false by default, in v1.5.0 works as true
 
+Security:
+- [BC Break] You may need set `erase_credentials` setting to `false` if you encounter problems when the user
+ reauthenticate. See [issue#76](https://github.com/Maks3w/FR3DLdapBundle/issues/76) for more details.
+
 ### v1.5.2, v1.6.1  (2012-02-18)
 
 * Add support for Composer package manager now you can find this bundle in http://www.packagist.org

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -49,6 +49,10 @@ public function registerBundles()
 # app/config/security.yml
 
 security:
+  # Preserve plain text password in token for refresh the user.
+  # Analyze the security considerations before turn off this setting.
+  erase_credentials: false
+
   firewalls:
     main:
       pattern:    ^/

--- a/Security/Authentication/LdapAuthenticationProvider.php
+++ b/Security/Authentication/LdapAuthenticationProvider.php
@@ -71,12 +71,19 @@ class LdapAuthenticationProvider extends UserAuthenticationProvider
     protected function checkAuthentication(UserInterface $user, UsernamePasswordToken $token)
     {
         $currentUser = $token->getUser();
+        $presentedPassword = $token->getCredentials();
         if ($currentUser instanceof UserInterface) {
-            if (!$this->ldapManager->bind($currentUser, $currentUser->getPassword())) {
+            if ('' === $presentedPassword) {
+                throw new BadCredentialsException(
+                    'The password in the token is empty. You may forgive turn off `erase_credentials` in your `security.yml`'
+                );
+            }
+
+            if (!$this->ldapManager->bind($currentUser, $presentedPassword)) {
                 throw new BadCredentialsException('The credentials were changed from another session.');
             }
         } else {
-            if ('' === ($presentedPassword = $token->getCredentials())) {
+            if ('' === $presentedPassword) {
                 throw new BadCredentialsException('The presented password cannot be empty.');
             }
 

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -64,3 +64,11 @@ UPGRADE FROM 1.5 to 2.0
         <argument>%fr3d_ldap.ldap_manager.parameters%</argument>
     </service>
     ```
+
+* `checkAuthentication()` now reauthenticate current user using token `getCrendetials()` instead `getPassword()`
+
+   Turn off `erase_credentials` in application `security.yml`:
+   ```yml
+   # app/config/security.yml
+   erase_credentials: false
+   ```


### PR DESCRIPTION
The correct way of verify user authentication is binding again against the LDAP backend with the original credentials used on login.
This is the token `getCredentials()` method.