### PR TITLE
Fixed logDebug when dealing with array

### DIFF
--- a/Driver/LdapDriverInterface.php
+++ b/Driver/LdapDriverInterface.php
@@ -28,7 +28,7 @@ interface LdapDriverInterface
      * Search LDAP tree.
      *
      * @param  string        $baseDn     The base DN for the directory.
-     * @param  string        $filter     The search filter.
+     * @param  string|array  $filter     The search filter.
      * @param  array         $attributes The array of the required attributes,
      *                                   'dn' is always returned. If array is
      *                                   empty then will return all attributes

--- a/Driver/ZendLdapDriver.php
+++ b/Driver/ZendLdapDriver.php
@@ -42,7 +42,7 @@ class ZendLdapDriver implements LdapDriverInterface
      */
     public function search($baseDn, $filter, array $attributes = array())
     {
-        $this->logDebug(sprintf('ldap_search(%s, %s, %s)', $baseDn, $filter, implode(',', $attributes)));
+        $this->logDebug(sprintf('ldap_search(%s, %s, %s)', $baseDn, json_encode($filter), implode(',', $attributes)));
 
         try {
             $entries          = $this->driver->searchEntries($filter, $baseDn, Ldap::SEARCH_SCOPE_SUB, $attributes);


### PR DESCRIPTION
Hi,

I personally use your bundle to display a Ldap Directory on my web application.
As you might know, the ZendDriver:searchEntries filter parameter can be used to pass additional options as sort or limit for instance.

I had to override the driver because logDebug crash an error when filter is an array.

PS : I think this PR can be merged in 2.0 too as there is no BC