### PR TITLE
Deprecated interface has been removed in Symfony 3.0

### DIFF
--- a/Driver/ZendLdapDriver.php
+++ b/Driver/ZendLdapDriver.php
@@ -3,7 +3,7 @@
 namespace FR3D\LdapBundle\Driver;
 
 use FR3D\LdapBundle\Model\LdapUserInterface;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Zend\Ldap\Exception\LdapException as ZendLdapException;
 use Zend\Ldap\Ldap;

--- a/Security/User/LdapUserProvider.php
+++ b/Security/User/LdapUserProvider.php
@@ -3,7 +3,7 @@
 namespace FR3D\LdapBundle\Security\User;
 
 use FR3D\LdapBundle\Ldap\LdapManagerInterface;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -15,6 +15,8 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 class LdapUserProvider implements UserProviderInterface
 {
     protected $ldapManager;
+
+    protected $logger;
 
     public function __construct(LdapManagerInterface $ldapManager, LoggerInterface $logger = null)
     {


### PR DESCRIPTION
Deprecated (deprecated since Symfony 2.2) LoggerInterface has been removed.
Dynamically declared attribute is added.