### PR TITLE
LDAP create user only if needed and multiple auth provider

### DIFF
--- a/Hydrator/AbstractHydrator.php
+++ b/Hydrator/AbstractHydrator.php
@@ -16,6 +16,11 @@ abstract class AbstractHydrator implements HydratorInterface
      */
     private $attributeMap;
 
+    /**
+     * @var Array
+     */
+    protected $ldapEntry;
+
     public function __construct(array $attributeMap)
     {
         $this->attributeMap = $attributeMap['attributes'];
@@ -26,6 +31,7 @@ abstract class AbstractHydrator implements HydratorInterface
      */
     public function hydrate(array $ldapEntry)
     {
+        $this->ldapEntry = $ldapEntry;
         $user = $this->createUser();
 
         $this->hydrateUserWithAttributesMap($user, $ldapEntry, $this->attributeMap);

--- a/Hydrator/LegacyHydrator.php
+++ b/Hydrator/LegacyHydrator.php
@@ -33,11 +33,17 @@ final class LegacyHydrator extends AbstractHydrator
      */
     protected function createUser()
     {
-        $user = $this->userManager->createUser();
-        $user->setPassword('');
+        if (!$this->ldapEntry) {
+            throw new \Exception("Cannot hydrate user since we do not have LDAP entry data");
+        }
+        $user = $this->userManager->findUserBy(array('dn' => $this->ldapEntry['dn']));
 
-        if ($user instanceof AdvancedUserInterface) {
-            $user->setEnabled(true);
+        if (!$user) {
+            $user = $this->userManager->createUser();
+            $user->setPassword('');
+            if ($user instanceof AdvancedUserInterface) {
+                $user->setEnabled(true);
+            }
         }
 
         return $user;

--- a/Security/Authentication/LdapAuthenticationProvider.php
+++ b/Security/Authentication/LdapAuthenticationProvider.php
@@ -11,6 +11,7 @@ use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+use FR3D\LdapBundle\Ldap\LdapManagerInterface;
 
 class LdapAuthenticationProvider extends UserAuthenticationProvider
 {
@@ -79,16 +80,24 @@ class LdapAuthenticationProvider extends UserAuthenticationProvider
                 );
             }
 
-            if (!$this->ldapManager->bind($currentUser, $presentedPassword)) {
-                throw new BadCredentialsException('The credentials were changed from another session.');
+            try {
+                if (!$this->ldapManager->bind($currentUser, $presentedPassword)) {
+                    throw new BadCredentialsException('The credentials were changed from another session.');
+                }
+            } catch (LdapException $e) {
+                throw new BadCredentialsException('An error occured while authentication against LDAP.');
             }
         } else {
             if ('' === $presentedPassword) {
                 throw new BadCredentialsException('The presented password cannot be empty.');
             }
 
-            if (!$this->ldapManager->bind($user, $presentedPassword)) {
-                throw new BadCredentialsException('The presented password is invalid.');
+            try {
+                if (!$this->ldapManager->bind($user, $presentedPassword)) {
+                    throw new BadCredentialsException('The presented password is invalid.');
+                }
+            } catch (LdapException $e) {
+                throw new BadCredentialsException('An error occured while authentication against LDAP.');
             }
         }
     }


### PR DESCRIPTION
- In our case, we use many auth provider. When checking users that are not from LDAP, an exception occured «malfromed DN» in Zend’s LDAP client. To avoid it, we catch those errors and throw a simple InvalidCredentialException to switch to others authentication providers.
- It seems that the LegacyProvider allways create a new user, but never search for an existing with the same DN. So I added this feature : search the user with user provider before 

I made those changes through class overiding in my application successfully, so I just wante to share this work.

Thanks for sharing this bundle.