### PR TITLE
Added catch for ContextErrorException which is thrown when attempting…

### DIFF
--- a/Security/Authentication/LdapAuthenticationProvider.php
+++ b/Security/Authentication/LdapAuthenticationProvider.php
@@ -3,6 +3,7 @@
 namespace FR3D\LdapBundle\Security\Authentication;
 
 use FR3D\LdapBundle\Ldap\LdapManagerInterface;
+use Symfony\Component\Debug\Exception\ContextErrorException;
 use Symfony\Component\Security\Core\Authentication\Provider\UserAuthenticationProvider;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationServiceException;
@@ -87,8 +88,12 @@ class LdapAuthenticationProvider extends UserAuthenticationProvider
                 throw new BadCredentialsException('The presented password cannot be empty.');
             }
 
-            if (!$this->ldapManager->bind($user, $presentedPassword)) {
-                throw new BadCredentialsException('The presented password is invalid.');
+            try {
+                if ( ! $this->ldapManager->bind($user, $presentedPassword)) {
+                    throw new BadCredentialsException('The presented password is invalid.');
+                }
+            } catch(ContextErrorException $e) {
+                throw new BadCredentialsException($e->getMessage());
             }
         }
     }


### PR DESCRIPTION
… to bind with a correct username but incorrect password. This is an issue that I had, there's a chance it's due to incorrect configuration on my part, but it solved my problem.