### PR TITLE
checks for NULL password

### DIFF
--- a/Security/Authentication/LdapAuthenticationProvider.php
+++ b/Security/Authentication/LdapAuthenticationProvider.php
@@ -67,7 +67,7 @@ class LdapAuthenticationProvider extends UserAuthenticationProvider
         $currentUser = $token->getUser();
         $presentedPassword = $token->getCredentials();
         if ($currentUser instanceof UserInterface) {
-            if ('' === $presentedPassword || NULL === $presentedPassword) {
+            if ('' === $presentedPassword || null === $presentedPassword) {
                 throw new BadCredentialsException(
                     'The password in the token is empty. You may forgive turn off `erase_credentials` in your `security.yml`'
                 );
@@ -77,7 +77,7 @@ class LdapAuthenticationProvider extends UserAuthenticationProvider
                 throw new BadCredentialsException('The credentials were changed from another session.');
             }
         } else {
-            if ('' === $presentedPassword || NULL === $presentedPassword) {
+            if ('' === $presentedPassword || null === $presentedPassword) {
                 throw new BadCredentialsException('The presented password cannot be empty.');
             }
 

--- a/Security/Authentication/LdapAuthenticationProvider.php
+++ b/Security/Authentication/LdapAuthenticationProvider.php
@@ -67,7 +67,7 @@ class LdapAuthenticationProvider extends UserAuthenticationProvider
         $currentUser = $token->getUser();
         $presentedPassword = $token->getCredentials();
         if ($currentUser instanceof UserInterface) {
-            if ('' === $presentedPassword) {
+            if ('' === $presentedPassword || NULL === $presentedPassword) {
                 throw new BadCredentialsException(
                     'The password in the token is empty. You may forgive turn off `erase_credentials` in your `security.yml`'
                 );
@@ -77,7 +77,7 @@ class LdapAuthenticationProvider extends UserAuthenticationProvider
                 throw new BadCredentialsException('The credentials were changed from another session.');
             }
         } else {
-            if ('' === $presentedPassword) {
+            if ('' === $presentedPassword || NULL === $presentedPassword) {
                 throw new BadCredentialsException('The presented password cannot be empty.');
             }
 

--- a/Tests/Security/Authentication/LdapAuthenticationProviderTest.php
+++ b/Tests/Security/Authentication/LdapAuthenticationProviderTest.php
@@ -264,16 +264,7 @@ class LdapAuthenticationProviderTest extends TestCase
     {
         return new UsernamePasswordToken($user, $credentials, 'provider_key');
     }
-
-    private function willBind(UserInterface $user, string $password, bool $result = true): void
-    {
-        $this->ldapManager->expects($this->once())
-            ->method('bind')
-            ->with($this->equalTo($user), $this->equalTo($password))
-            ->willReturn($result)
-        ;
-    }
-
+    
     private function willBind(UserInterface $user, string $password, bool $result = true): void
     {
         $this->ldapManager->expects($this->once())

--- a/Tests/Security/Authentication/LdapAuthenticationProviderTest.php
+++ b/Tests/Security/Authentication/LdapAuthenticationProviderTest.php
@@ -264,7 +264,7 @@ class LdapAuthenticationProviderTest extends TestCase
     {
         return new UsernamePasswordToken($user, $credentials, 'provider_key');
     }
-    
+
     private function willBind(UserInterface $user, string $password, bool $result = true): void
     {
         $this->ldapManager->expects($this->once())

--- a/Tests/Security/Authentication/LdapAuthenticationProviderTest.php
+++ b/Tests/Security/Authentication/LdapAuthenticationProviderTest.php
@@ -258,7 +258,7 @@ class LdapAuthenticationProviderTest extends TestCase
     }
 
     /**
-     * @param UserInterface|null|object $user
+     * @param UserInterface|string|object $user
      */
     private function createTokenWithNullPassword($user, ?string $credentials): UsernamePasswordToken
     {


### PR DESCRIPTION
Catches when frontend has not sent a parameter named "password" by checking for null. 

This addresses issue: https://github.com/Maks3w/FR3DLdapBundle/issues/164#issue-491243577